### PR TITLE
quiet_call: use Julia's built-in devnull instead of hardcoding /dev/null

### DIFF
--- a/src/SubModules/Tools.jl
+++ b/src/SubModules/Tools.jl
@@ -147,11 +147,9 @@ Notes
     properly restored when the call exits.
 """
 function quiet_call(f, args...; kwargs...)
-    open("/dev/null", "w") do devnull
-        redirect_stdout(devnull) do
-            redirect_stderr(devnull) do
-                return f(args...; kwargs...)
-            end
+    redirect_stdout(devnull) do
+        redirect_stderr(devnull) do
+            return f(args...; kwargs...)
         end
     end
 end


### PR DESCRIPTION
quiet_call(): use Julia's built-in devnull instead of hardcoding /dev/null

This makes sure quiet_call() is OS-agnostic rather than specific to Unix-like OSes
